### PR TITLE
Fix package.json github typos

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "toggl",
     "toggl-api"
   ],
-  "homepage": "https://gtihub.com/valenvb/node-red-contrib-toggl",
-  "repository": "https://gtihub.com/valenvb/node-red-contrib-toggl",
+  "homepage": "https://github.com/valenvb/node-red-contrib-toggl",
+  "repository": "https://github.com/valenvb/node-red-contrib-toggl",
   "bugs": {
     "url": "https://github.com/valenvb/node-red-contrib-toggl/issues"
   },


### PR DESCRIPTION
homepage and repository fields on package.json had **gtihub** instead of **github**